### PR TITLE
Add tests for organization type

### DIFF
--- a/src/schema/organization/__tests__/api.js
+++ b/src/schema/organization/__tests__/api.js
@@ -1,6 +1,158 @@
 import gql from 'graphql-tag';
 
 /**
+ * Query for testing the obtaining of all organization data.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `id`
+ *                          `name`
+ *                          `login`
+ *                          `avatarUrl`
+ *                          `url`
+ *                          `websiteUrl`
+ *                          `totalMembers`
+ *                          `totalRepos`
+ *                          `totalTeams`
+ *                          `totalPullRequests`
+ *                          `totalCommits`
+ *                          `totalIssues`
+ *                          of the desired organization
+ */
+const organizationData = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      id
+      name
+      login
+      avatarUrl
+      url
+      websiteUrl
+      totalMembers
+      totalRepos
+      totalTeams
+      totalPullRequests
+      totalCommits
+      totalIssues
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the organization id.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `id`
+ *                          of the desired organization
+ */
+const organizationId = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      id
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the organization name.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `name`
+ *                          of the desired organization
+ */
+const organizationName = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      name
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the organization login.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `login`
+ *                          of the desired organization
+ */
+const organizationLogin = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      login
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the organization website url.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `websiteUrl`
+ *                          of the desired organization
+ */
+const organizationWebsiteUrl = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      websiteUrl
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the number of repositories in an
+ * organization.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `totalRepos`
+ *                          of the desired organization
+ */
+const organizationTotalRepos = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      totalRepos
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the number of teams in an
+ * organization.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `totalTeams`
+ *                          of the desired organization
+ */
+const organizationTotalTeams = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      totalTeams
+    }
+  }
+`;
+
+/**
+ * Query for testing the obtaining of the number of members in an
+ * organization.
+ * 
+ * @param {String} login organization login
+ * @returns {OrganizationObject} an object containing the:
+ *                          `totalMembers`
+ *                          of the desired organization
+ */
+const organizationTotalMembers = gql`
+  query organizationData($login: String!) {
+    organization(login: $login) {
+      totalMembers
+    }
+  }
+`;
+/**
  * Query for testing the obtaining of the number of Pull Requests opened,
  * merged or closed in all repositories of one organization.
  * 
@@ -52,6 +204,14 @@ const organizationTotalCommits = gql`
 `;
 
 export {
+  organizationData,
+  organizationId,
+  organizationLogin,
+  organizationName,
+  organizationWebsiteUrl,
+  organizationTotalRepos,
+  organizationTotalMembers,
+  organizationTotalTeams,
   organizationTotalPullRequests,
   organizationTotalIssues,
   organizationTotalCommits,

--- a/src/schema/organization/__tests__/expectedResults.js
+++ b/src/schema/organization/__tests__/expectedResults.js
@@ -10,89 +10,12 @@ const organizationData =
     totalMembers: 10,
     totalRepos: 4,
     totalTeams: 4,
-    totalPullRequests: 55,
-    totalCommits: 253,
+    totalPullRequests: 59,
+    totalCommits: 270,
     totalIssues: 84,
   }
 }
-
-const organizationId =
-{
-  organization: {
-    id: "MDEyOk9yZ2FuaXphdGlvbjQ5MTI5MTEx",
-  }
-}
-
-const organizationName =
-{
-  organization: {
-    name: "panelinhadees",
-  }
-}
-
-const organizationLogin =
-{
-  organization: {
-    login: "panelinhadees",
-  }
-}
-
-const organizationWebsiteUrl =
-{
-  organization: {
-    websiteUrl: null,
-  }
-}
-
-const organizationTotalMembers =
-{
-  organization: {
-    totalMembers: 10,
-  }
-}
-
-const organizationTotalTeams =
-{
-  organization: {
-    totalTeams: 4,
-  }
-}
-
-const organizationTotalRepos =
-{
-  organization: {
-    totalRepos: 4,
-  }
-}
-
-const organizationTotalPullRequests = {
-  organization: {
-    totalPullRequests: 55,
-  }
-};
-
-const organizationTotalIssues = {
-  organization: {
-    totalIssues: 84,
-  }
-};
-
-const organizationTotalCommits = {
-  organization: {
-    totalCommits: 253,
-  }
-};
 
 export {
   organizationData,
-  organizationId,
-  organizationLogin,
-  organizationName,
-  organizationWebsiteUrl,
-  organizationTotalTeams,
-  organizationTotalRepos,
-  organizationTotalMembers,
-  organizationTotalPullRequests,
-  organizationTotalIssues,
-  organizationTotalCommits,
 }

--- a/src/schema/organization/__tests__/expectedResults.js
+++ b/src/schema/organization/__tests__/expectedResults.js
@@ -1,3 +1,70 @@
+const organizationData =
+{
+  organization: {
+    id: "MDEyOk9yZ2FuaXphdGlvbjQ5MTI5MTEx",
+    name: "panelinhadees",
+    login: "panelinhadees",
+    avatarUrl: "https://avatars0.githubusercontent.com/u/49129111?v=4",
+    url: "https://github.com/panelinhadees",
+    websiteUrl: null,
+    totalMembers: 10,
+    totalRepos: 4,
+    totalTeams: 4,
+    totalPullRequests: 55,
+    totalCommits: 253,
+    totalIssues: 84,
+  }
+}
+
+const organizationId =
+{
+  organization: {
+    id: "MDEyOk9yZ2FuaXphdGlvbjQ5MTI5MTEx",
+  }
+}
+
+const organizationName =
+{
+  organization: {
+    name: "panelinhadees",
+  }
+}
+
+const organizationLogin =
+{
+  organization: {
+    login: "panelinhadees",
+  }
+}
+
+const organizationWebsiteUrl =
+{
+  organization: {
+    websiteUrl: null,
+  }
+}
+
+const organizationTotalMembers =
+{
+  organization: {
+    totalMembers: 10,
+  }
+}
+
+const organizationTotalTeams =
+{
+  organization: {
+    totalTeams: 4,
+  }
+}
+
+const organizationTotalRepos =
+{
+  organization: {
+    totalRepos: 4,
+  }
+}
+
 const organizationTotalPullRequests = {
   organization: {
     totalPullRequests: 55,
@@ -6,17 +73,25 @@ const organizationTotalPullRequests = {
 
 const organizationTotalIssues = {
   organization: {
-    totalIssues: 83,
+    totalIssues: 84,
   }
 };
 
 const organizationTotalCommits = {
   organization: {
-    totalCommits: 227,
+    totalCommits: 253,
   }
 };
 
 export {
+  organizationData,
+  organizationId,
+  organizationLogin,
+  organizationName,
+  organizationWebsiteUrl,
+  organizationTotalTeams,
+  organizationTotalRepos,
+  organizationTotalMembers,
   organizationTotalPullRequests,
   organizationTotalIssues,
   organizationTotalCommits,

--- a/src/schema/organization/__tests__/organization.spec.js
+++ b/src/schema/organization/__tests__/organization.spec.js
@@ -2,10 +2,12 @@ import { createTestClient } from 'apollo-server-testing';
 import * as queries from './api';
 import * as expectedResults from './expectedResults';
 import testServer from '../../../testUtils/integration/serverFactory';
+import { getPropsFromList } from '../../../testUtils/integration/dataExtractor';
 
 describe('Organization type tests', () => {
   const login = 'panelinhadees';
   const { query } = createTestClient(testServer);
+  const organizationPath = [];
 
   it('organization: Organization', async () => {
     const { data } = await(query({
@@ -20,7 +22,14 @@ describe('Organization type tests', () => {
       query: queries.organizationId,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationId);
+
+    const organizationIdExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['id'],
+    );
+
+    expect(data).toEqual(organizationIdExpectedResult);
   });
 
   it('organization: { login }: Organization', async () => {
@@ -28,7 +37,14 @@ describe('Organization type tests', () => {
       query: queries.organizationLogin,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationLogin);
+
+    const organizationLoginExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['login'],
+    );
+    
+    expect(data).toEqual(organizationLoginExpectedResult);
   });
 
   it('organization: { name }: Organization', async () => {
@@ -36,7 +52,14 @@ describe('Organization type tests', () => {
       query: queries.organizationName,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationName);
+    
+    const organizationNameExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['name'],
+    );
+    
+    expect(data).toEqual(organizationNameExpectedResult);
   });
 
   it('organization: { websiteUrl }: Organization', async () => {
@@ -44,7 +67,14 @@ describe('Organization type tests', () => {
       query: queries.organizationWebsiteUrl,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationWebsiteUrl);
+    
+    const organizationWebsiteUrlExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['websiteUrl'],
+    );
+    
+    expect(data).toEqual(organizationWebsiteUrlExpectedResult);
   });
 
   it('organization: { totalMembers }: Organization', async () => {
@@ -52,7 +82,14 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalMembers,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalMembers);
+    
+    const organizationTotalMembersExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalMembers'],
+    );
+    
+    expect(data).toEqual(organizationTotalMembersExpectedResult);
   });
 
   it('organization: { totalRepos }: Organization', async () => {
@@ -60,7 +97,14 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalRepos,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalRepos);
+    
+    const organizationTotalReposExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalRepos'],
+    );
+    
+    expect(data).toEqual(organizationTotalReposExpectedResult);
   });
 
   it('organization: { totalTeams }: Organization', async () => {
@@ -68,7 +112,14 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalTeams,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalTeams);
+    
+    const organizationTotalTeamsExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalTeams'],
+    );
+    
+    expect(data).toEqual(organizationTotalTeamsExpectedResult);
   });
 
   it('organization: { totalPullRequests }: Organization', async () => {
@@ -76,7 +127,14 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalPullRequests,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalPullRequests);
+    
+    const organizationTotalPullRequestsExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalPullRequests'],
+    );
+    
+    expect(data).toEqual(organizationTotalPullRequestsExpectedResult);
   });
 
   it('organization: { totalIssues }: Organization', async () => {
@@ -84,7 +142,14 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalIssues,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalIssues);
+    
+    const organizationTotalIssuesExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalIssues'],
+    );
+    
+    expect(data).toEqual(organizationTotalIssuesExpectedResult);
   });
 
   it('organization: { totalCommits }: Organization', async () => {
@@ -92,6 +157,13 @@ describe('Organization type tests', () => {
       query: queries.organizationTotalCommits,
       variables: { login },
     }));
-    expect(data).toEqual(expectedResults.organizationTotalCommits);
+    
+    const organizationTotalCommitsExpectedResult = getPropsFromList(
+      expectedResults.organizationData,
+      organizationPath,
+      ['totalCommits'],
+    );
+    
+    expect(data).toEqual(organizationTotalCommitsExpectedResult);
   });
 })

--- a/src/schema/organization/__tests__/organization.spec.js
+++ b/src/schema/organization/__tests__/organization.spec.js
@@ -7,6 +7,70 @@ describe('Organization type tests', () => {
   const login = 'panelinhadees';
   const { query } = createTestClient(testServer);
 
+  it('organization: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationData,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationData);
+  });
+
+  it('organization: { id }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationId,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationId);
+  });
+
+  it('organization: { login }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationLogin,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationLogin);
+  });
+
+  it('organization: { name }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationName,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationName);
+  });
+
+  it('organization: { websiteUrl }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationWebsiteUrl,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationWebsiteUrl);
+  });
+
+  it('organization: { totalMembers }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationTotalMembers,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationTotalMembers);
+  });
+
+  it('organization: { totalRepos }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationTotalRepos,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationTotalRepos);
+  });
+
+  it('organization: { totalTeams }: Organization', async () => {
+    const { data } = await(query({
+      query: queries.organizationTotalTeams,
+      variables: { login },
+    }));
+    expect(data).toEqual(expectedResults.organizationTotalTeams);
+  });
+
   it('organization: { totalPullRequests }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalPullRequests,


### PR DESCRIPTION
# Description

This pr adds tests for Organization type

Fixes #89.
## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
To be able to use the tests correctly, you will need to define a github token that will be used for the tests of the requisitions, it is set in .env, check the .env.example in the project root, once you have defined the same execute the command:

`npm run test`

Note: Currently the expectedResult is set for the `panelinhadees` organization, just as an example, however, if you use your token, it will be another user logged in, so in order for it to work you should replace its information with your.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules