### PR TITLE
Feat/63 add pr count repository

### DIFF
--- a/src/github/queries.js
+++ b/src/github/queries.js
@@ -135,6 +135,9 @@ const organizationRepositories = (login, pagination) => {
       issues(states: OPEN) {
         totalCount
       }
+      pullRequests(states: OPEN) {
+        totalCount
+      }
       stargazers {
         totalCount
       }

--- a/src/schema/organization/repositories/__tests__/api.js
+++ b/src/schema/organization/repositories/__tests__/api.js
@@ -12,6 +12,7 @@ import gql from 'graphql-tag';
  *                   `viewerCanAdminister`
  *                   `totalForks`
  *                   `totalOpenIssues`
+ *                   `totalOpenPullRequests`
  *                   `totalStars`
  *                   of the desired `organization`
  * */
@@ -24,6 +25,7 @@ const repositories = gql`
         viewerCanAdminister
         totalForks
         totalOpenIssues
+        totalOpenPullRequests
         totalStars
       }
     }

--- a/src/schema/organization/repositories/__tests__/expectedResults.js
+++ b/src/schema/organization/repositories/__tests__/expectedResults.js
@@ -2,10 +2,10 @@ const repositoriesTotalCommits = {
   organization: {
     repositories: [
       {
-        totalCommits: 156,
+        totalCommits: 195,
       },
       {
-        totalCommits: 54,
+        totalCommits: 55,
       },
       {
         totalCommits: 6,
@@ -25,7 +25,8 @@ const repositories = {
         name: 'panelinhadees/server',
         viewerCanAdminister: true,
         totalForks: 0,
-        totalOpenIssues: 16,
+        totalOpenIssues: 8,
+        totalOpenPullRequests: 3,
         totalStars: 5,
       },
       {
@@ -33,7 +34,8 @@ const repositories = {
         name: 'panelinhadees/client',
         viewerCanAdminister: true,
         totalForks: 0,
-        totalOpenIssues: 11,
+        totalOpenIssues: 13,
+        totalOpenPullRequests: 3,
         totalStars: 6,
       },
       {
@@ -42,6 +44,7 @@ const repositories = {
         viewerCanAdminister: true,
         totalForks: 0,
         totalOpenIssues: 1,
+        totalOpenPullRequests: 0,
         totalStars: 1,
       },
       {
@@ -50,6 +53,7 @@ const repositories = {
         viewerCanAdminister: true,
         totalForks: 0,
         totalOpenIssues: 0,
+        totalOpenPullRequests: 0, 
         totalStars: 0,
       },
     ],

--- a/src/schema/organization/repositories/resolvers.js
+++ b/src/schema/organization/repositories/resolvers.js
@@ -8,6 +8,7 @@ const addReposToArray = (repos, reposArray) => {
     const repoForks = repo.forkCount;
     const repoViewerAdmin = repo.viewerCanAdminister;
     const repoIssues = repo.issues.totalCount;
+    const repoPullRequests = repo.pullRequests.totalCount;
     const repoStars = repo.stargazers.totalCount;
 
     const numberofCommits = repo.object.history.totalCount;
@@ -18,6 +19,7 @@ const addReposToArray = (repos, reposArray) => {
       viewerCanAdminister: repoViewerAdmin,
       totalForks: repoForks,
       totalOpenIssues: repoIssues,
+      totalOpenPullRequests: repoPullRequests,
       totalStars: repoStars,
       totalCommits: numberofCommits,
     });

--- a/src/schema/organization/repositories/types.js
+++ b/src/schema/organization/repositories/types.js
@@ -16,6 +16,7 @@ const RepositoryType = new GraphQLObjectType({
     viewerCanAdminister: { type: GraphQLBoolean },
     totalForks: { type: GraphQLInt },
     totalOpenIssues: { type: GraphQLInt },
+    totalOpenPullRequests: { type: GraphQLInt },
     totalStars: { type: GraphQLInt },
     totalCommits: { type: GraphQLInt },
   }),


### PR DESCRIPTION
# Description

This PR adds a new field to `Repository` type, called `totalOpenPullRequests`, as well as its resolvers, query and tests.

Fixes #63.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
To be able to use the tests correctly, you will need to define a github token that will be used for the tests of the requisitions, it is set in .env, check the .env.example in the project root, once you have defined the same execute the command:

`npm run test`

Note: Currently the expectedResult is set for the `panelinhadees` organization, just as an example, however, if you use your token, it will be another user logged in, so in order for it to work you should replace its information with your.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules