### PR TITLE
Feat/93 use dotenv organization login

### DIFF
--- a/src/schema/organization/__tests__/api.js
+++ b/src/schema/organization/__tests__/api.js
@@ -3,7 +3,6 @@ import gql from 'graphql-tag';
 /**
  * Query for testing the obtaining of all organization data.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `id`
  *                          `name`
@@ -20,8 +19,8 @@ import gql from 'graphql-tag';
  *                          of the desired organization
  */
 const organizationData = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       id
       name
       login
@@ -41,14 +40,13 @@ const organizationData = gql`
 /**
  * Query for testing the obtaining of the organization id.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `id`
  *                          of the desired organization
  */
 const organizationId = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       id
     }
   }
@@ -57,14 +55,13 @@ const organizationId = gql`
 /**
  * Query for testing the obtaining of the organization name.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `name`
  *                          of the desired organization
  */
 const organizationName = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       name
     }
   }
@@ -73,14 +70,13 @@ const organizationName = gql`
 /**
  * Query for testing the obtaining of the organization login.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `login`
  *                          of the desired organization
  */
 const organizationLogin = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       login
     }
   }
@@ -89,14 +85,13 @@ const organizationLogin = gql`
 /**
  * Query for testing the obtaining of the organization website url.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `websiteUrl`
  *                          of the desired organization
  */
 const organizationWebsiteUrl = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       websiteUrl
     }
   }
@@ -106,14 +101,13 @@ const organizationWebsiteUrl = gql`
  * Query for testing the obtaining of the number of repositories in an
  * organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalRepos`
  *                          of the desired organization
  */
 const organizationTotalRepos = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalRepos
     }
   }
@@ -123,14 +117,13 @@ const organizationTotalRepos = gql`
  * Query for testing the obtaining of the number of teams in an
  * organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalTeams`
  *                          of the desired organization
  */
 const organizationTotalTeams = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalTeams
     }
   }
@@ -140,14 +133,13 @@ const organizationTotalTeams = gql`
  * Query for testing the obtaining of the number of members in an
  * organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalMembers`
  *                          of the desired organization
  */
 const organizationTotalMembers = gql`
-  query organizationData($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalMembers
     }
   }
@@ -156,14 +148,13 @@ const organizationTotalMembers = gql`
  * Query for testing the obtaining of the number of Pull Requests opened,
  * merged or closed in all repositories of one organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalPullRequests`
  *                          of the desired organization
  */
 const organizationTotalPullRequests = gql`
-  query orgPRs($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalPullRequests
     }
   }
@@ -173,14 +164,13 @@ const organizationTotalPullRequests = gql`
  * Query for testing the obtaining of the number of issues opened or closes
  * in all repositories of one organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalIssues`
  *                          of the desired organization
  */
 const organizationTotalIssues = gql`
-  query orgPRs($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalIssues
     }
   }
@@ -190,14 +180,13 @@ const organizationTotalIssues = gql`
  * Query for testing the obtaining of the number of commits to all repositories
  * of one organization.
  * 
- * @param {String} login organization login
  * @returns {OrganizationObject} an object containing the:
  *                          `totalCommits`
  *                          of the desired organization
  */
 const organizationTotalCommits = gql`
-  query orgPRs($login: String!) {
-    organization(login: $login) {
+  query {
+    organization {
       totalCommits
     }
   }

--- a/src/schema/organization/__tests__/expectedResults.js
+++ b/src/schema/organization/__tests__/expectedResults.js
@@ -8,11 +8,11 @@ const organizationData =
     url: "https://github.com/panelinhadees",
     websiteUrl: null,
     totalMembers: 10,
-    totalRepos: 4,
+    totalRepos: 5,
     totalTeams: 4,
     totalPullRequests: 59,
-    totalCommits: 270,
-    totalIssues: 84,
+    totalCommits: 275,
+    totalIssues: 85,
   }
 }
 

--- a/src/schema/organization/__tests__/organization.spec.js
+++ b/src/schema/organization/__tests__/organization.spec.js
@@ -5,14 +5,12 @@ import testServer from '../../../testUtils/integration/serverFactory';
 import { getPropsFromList } from '../../../testUtils/integration/dataExtractor';
 
 describe('Organization type tests', () => {
-  const login = 'panelinhadees';
   const { query } = createTestClient(testServer);
   const organizationPath = [];
 
   it('organization: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationData,
-      variables: { login },
     }));
     expect(data).toEqual(expectedResults.organizationData);
   });
@@ -20,7 +18,6 @@ describe('Organization type tests', () => {
   it('organization: { id }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationId,
-      variables: { login },
     }));
 
     const organizationIdExpectedResult = getPropsFromList(
@@ -35,7 +32,6 @@ describe('Organization type tests', () => {
   it('organization: { login }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationLogin,
-      variables: { login },
     }));
 
     const organizationLoginExpectedResult = getPropsFromList(
@@ -50,7 +46,6 @@ describe('Organization type tests', () => {
   it('organization: { name }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationName,
-      variables: { login },
     }));
     
     const organizationNameExpectedResult = getPropsFromList(
@@ -65,7 +60,6 @@ describe('Organization type tests', () => {
   it('organization: { websiteUrl }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationWebsiteUrl,
-      variables: { login },
     }));
     
     const organizationWebsiteUrlExpectedResult = getPropsFromList(
@@ -80,7 +74,6 @@ describe('Organization type tests', () => {
   it('organization: { totalMembers }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalMembers,
-      variables: { login },
     }));
     
     const organizationTotalMembersExpectedResult = getPropsFromList(
@@ -95,7 +88,6 @@ describe('Organization type tests', () => {
   it('organization: { totalRepos }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalRepos,
-      variables: { login },
     }));
     
     const organizationTotalReposExpectedResult = getPropsFromList(
@@ -110,7 +102,6 @@ describe('Organization type tests', () => {
   it('organization: { totalTeams }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalTeams,
-      variables: { login },
     }));
     
     const organizationTotalTeamsExpectedResult = getPropsFromList(
@@ -125,7 +116,6 @@ describe('Organization type tests', () => {
   it('organization: { totalPullRequests }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalPullRequests,
-      variables: { login },
     }));
     
     const organizationTotalPullRequestsExpectedResult = getPropsFromList(
@@ -140,7 +130,6 @@ describe('Organization type tests', () => {
   it('organization: { totalIssues }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalIssues,
-      variables: { login },
     }));
     
     const organizationTotalIssuesExpectedResult = getPropsFromList(
@@ -155,7 +144,6 @@ describe('Organization type tests', () => {
   it('organization: { totalCommits }: Organization', async () => {
     const { data } = await(query({
       query: queries.organizationTotalCommits,
-      variables: { login },
     }));
     
     const organizationTotalCommitsExpectedResult = getPropsFromList(

--- a/src/schema/organization/members/__tests__/api.js
+++ b/src/schema/organization/members/__tests__/api.js
@@ -14,8 +14,8 @@ import gql from 'graphql-tag';
  *                   of the desired `organization`
  * */
 const members = gql`
-  query members($login: String!, $maxNumberOfMembers: Int!) {
-    organization(login: $login) {
+  query members($maxNumberOfMembers: Int!) {
+    organization {
       members(maxNumberOfMembers: $maxNumberOfMembers) {
         id
         name
@@ -36,8 +36,8 @@ const members = gql`
  *                   of the desired `organization`
  * */
 const membersName = gql`
-  query membersName($login: String!, $maxNumberOfMembers: Int!) {
-    organization(login: $login) {
+  query membersName($maxNumberOfMembers: Int!) {
+    organization {
       members(maxNumberOfMembers: $maxNumberOfMembers) {
         name
       }
@@ -55,8 +55,8 @@ const membersName = gql`
  *                   of the desired `organization`
  * */
 const membersIdLogin = gql`
-  query membersIdLogin($login: String!, $maxNumberOfMembers: Int!) {
-    organization(login: $login) {
+  query membersIdLogin($maxNumberOfMembers: Int!) {
+    organization {
       members(maxNumberOfMembers: $maxNumberOfMembers) {
         id
         login
@@ -76,8 +76,8 @@ const membersIdLogin = gql`
  *                   of the desired `organization`
  * */
 const membersLoginRoleUrl = gql`
-  query membersLoginRoleUrl($login: String!, $maxNumberOfMembers: Int!) {
-    organization(login: $login) {
+  query membersLoginRoleUrl($maxNumberOfMembers: Int!) {
+    organization {
       members(maxNumberOfMembers: $maxNumberOfMembers) {
         role
         login
@@ -99,8 +99,8 @@ const membersLoginRoleUrl = gql`
  *                   of the desired `organization`
  * */
 const membersNameLoginRoleUrl = gql`
-  query membersNameLoginRoleUrl($login: String!, $maxNumberOfMembers: Int!) {
-    organization(login: $login) {
+  query membersNameLoginRoleUrl($maxNumberOfMembers: Int!) {
+    organization {
       members(maxNumberOfMembers: $maxNumberOfMembers) {
         name
         login

--- a/src/schema/organization/members/__tests__/expectedResults.js
+++ b/src/schema/organization/members/__tests__/expectedResults.js
@@ -33,7 +33,7 @@ const members = {
         id: 'MDQ6VXNlcjE1Mzg5Mzg0',
         name: 'Marcus Vinícius',
         login: 'vinifarias',
-        role: 'MEMBER',
+        role: 'ADMIN',
         url: 'https://github.com/vinifarias',
       },
       {
@@ -47,14 +47,14 @@ const members = {
         id: 'MDQ6VXNlcjMwMjQ3NTE5',
         name: 'Matheus Alves',
         login: 'SpinnelSun',
-        role: 'MEMBER',
+        role: 'ADMIN',
         url: 'https://github.com/SpinnelSun',
       },
       {
         id: 'MDQ6VXNlcjMzMjg2NDQy',
         name: 'Mateus Oliveira',
         login: 'mateusoliveira2',
-        role: 'MEMBER',
+        role: 'ADMIN',
         url: 'https://github.com/mateusoliveira2',
       },
       {

--- a/src/schema/organization/members/__tests__/members.spec.js
+++ b/src/schema/organization/members/__tests__/members.spec.js
@@ -5,7 +5,6 @@ import testServer from '../../../../testUtils/integration/serverFactory';
 import { getPropsFromList } from '../../../../testUtils/integration/dataExtractor';
 
 describe('Member type tests', () => {
-  const login = 'panelinhadees';
   const maxNumberOfMembers = 10;
   const membersPath = ['organization', 'members'];
   const { query } = createTestClient(testServer);
@@ -13,7 +12,7 @@ describe('Member type tests', () => {
   it('members: OrganizationMember', async () => {
     const { data } = await query({
       query: queries.members,
-      variables: { login, maxNumberOfMembers },
+      variables: { maxNumberOfMembers },
     });
     expect(data).toEqual(expectedResult.members);
   });
@@ -21,7 +20,7 @@ describe('Member type tests', () => {
   it('members: { name }: OrganizationMember', async () => {
     const { data } = await query({
       query: queries.membersName,
-      variables: { login, maxNumberOfMembers },
+      variables: { maxNumberOfMembers },
     });
     
     const expectedResultMembersName = getPropsFromList(
@@ -35,7 +34,7 @@ describe('Member type tests', () => {
   it('members: { id, login }: OrganizationMember', async () => {
     const { data } = await query({
       query: queries.membersIdLogin,
-      variables: { login, maxNumberOfMembers },
+      variables: { maxNumberOfMembers },
     });
 
     const expectedResultMembersIdLogin = getPropsFromList(
@@ -49,7 +48,7 @@ describe('Member type tests', () => {
   it('members: { login, role, url }: OrganizationMember', async () => {
     const { data } = await query({
       query: queries.membersLoginRoleUrl,
-      variables: { login, maxNumberOfMembers },
+      variables: { maxNumberOfMembers },
     });
 
     const expectedResultMembersLoginRoleUrl = getPropsFromList(
@@ -60,10 +59,10 @@ describe('Member type tests', () => {
     expect(data).toEqual(expectedResultMembersLoginRoleUrl);
   });
 
-  it('members: { name, login, role, url }: OrganizationMember', async () => {
+  it('members: { login, name, role, url }: OrganizationMember', async () => {
     const { data } = await query({
       query: queries.membersNameLoginRoleUrl,
-      variables: { login, maxNumberOfMembers },
+      variables: { maxNumberOfMembers },
     });
 
     const expectedResultMembersNameLoginRoleUrl = getPropsFromList(

--- a/src/schema/organization/queries.js
+++ b/src/schema/organization/queries.js
@@ -1,16 +1,8 @@
-import { GraphQLString, GraphQLNonNull } from 'graphql';
-
 import OrganizationType from './types';
 import resolvers from './resolvers';
 
 const organization = {
   type: OrganizationType,
-  args: {
-    login: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: 'Organization login on Github',
-    },
-  },
   resolve: resolvers.Query.organization,
 };
 

--- a/src/schema/organization/repositories/__tests__/api.js
+++ b/src/schema/organization/repositories/__tests__/api.js
@@ -17,8 +17,8 @@ import gql from 'graphql-tag';
  *                   of the desired `organization`
  * */
 const repositories = gql`
-  query repositories($login: String!, $maxNumberOfRepositories: Int!) {
-    organization(login: $login) {
+  query repositories($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         id
         name
@@ -41,8 +41,8 @@ const repositories = gql`
  *                   of the desired `organization`
  * */
 const repositoriesName = gql`
-  query repositoriesName($login: String!, $maxNumberOfRepositories: Int!) {
-    organization(login: $login) {
+  query repositoriesName($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         name
       }
@@ -60,11 +60,8 @@ const repositoriesName = gql`
  *                   of the desired `organization`
  * */
 const repositoriesNameViewerCanAdminister = gql`
-  query repositoriesNameViewerCanAdminister(
-    $login: String!
-    $maxNumberOfRepositories: Int!
-  ) {
-    organization(login: $login) {
+  query repositoriesNameViewerCanAdminister($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         name
         viewerCanAdminister
@@ -84,11 +81,8 @@ const repositoriesNameViewerCanAdminister = gql`
  *                   of the desired `organization`
  * */
 const repositoriesTotalForksTotalOpenIssuesTotalStars = gql`
-  query repositoriesTotalForksTotalOpenIssuesTotalStars(
-    $login: String!
-    $maxNumberOfRepositories: Int!
-  ) {
-    organization(login: $login) {
+  query repositoriesTotalForksTotalOpenIssuesTotalStars($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         totalForks
         totalOpenIssues
@@ -110,11 +104,8 @@ const repositoriesTotalForksTotalOpenIssuesTotalStars = gql`
  *                   of the desired `organization`
  * */
 const repositoriesIdTotalForksTotalOpenIssuesTotalStars = gql`
-  query repositoriesIdTotalForksTotalOpenIssuesTotalStars(
-    $login: String!
-    $maxNumberOfRepositories: Int!
-  ) {
-    organization(login: $login) {
+  query repositoriesIdTotalForksTotalOpenIssuesTotalStars($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         id
         totalForks
@@ -134,11 +125,8 @@ const repositoriesIdTotalForksTotalOpenIssuesTotalStars = gql`
  *                      of the desired repository inside an organization.
  */
 const repositoriesTotalCommits = gql`
-  query repositoriesTotalCommits(
-    $login: String!
-    $maxNumberOfRepositories: Int!
-  ) {
-    organization(login: $login) {
+  query repositoriesTotalCommits($maxNumberOfRepositories: Int!) {
+    organization {
       repositories(maxNumberOfRepositories: $maxNumberOfRepositories) {
         totalCommits
       }

--- a/src/schema/organization/repositories/__tests__/expectedResults.js
+++ b/src/schema/organization/repositories/__tests__/expectedResults.js
@@ -2,7 +2,7 @@ const repositoriesTotalCommits = {
   organization: {
     repositories: [
       {
-        totalCommits: 195,
+        totalCommits: 202,
       },
       {
         totalCommits: 55,
@@ -12,6 +12,9 @@ const repositoriesTotalCommits = {
       },
       {
         totalCommits: 10,
+      },
+      {
+        totalCommits: 2,
       },
     ]
   }
@@ -25,8 +28,8 @@ const repositories = {
         name: 'panelinhadees/server',
         viewerCanAdminister: true,
         totalForks: 0,
-        totalOpenIssues: 8,
-        totalOpenPullRequests: 3,
+        totalOpenIssues: 5,
+        totalOpenPullRequests: 1,
         totalStars: 5,
       },
       {
@@ -35,7 +38,7 @@ const repositories = {
         viewerCanAdminister: true,
         totalForks: 0,
         totalOpenIssues: 13,
-        totalOpenPullRequests: 3,
+        totalOpenPullRequests: 4,
         totalStars: 6,
       },
       {
@@ -55,6 +58,15 @@ const repositories = {
         totalOpenIssues: 0,
         totalOpenPullRequests: 0, 
         totalStars: 0,
+      },
+      {
+        id: "MDEwOlJlcG9zaXRvcnkxODgwNzMyNzY=",
+        name: "panelinhadees/formal-specification",
+        viewerCanAdminister: true,
+        totalForks: 2,
+        totalOpenIssues: 0,
+        totalOpenPullRequests: 0,
+        totalStars: 3,
       },
     ],
   },

--- a/src/schema/organization/repositories/__tests__/repositories.spec.js
+++ b/src/schema/organization/repositories/__tests__/repositories.spec.js
@@ -5,15 +5,14 @@ import testServer from '../../../../testUtils/integration/serverFactory';
 import { getPropsFromList } from '../../../../testUtils/integration/dataExtractor';
 
 describe('Repository type tests', () => {
-  const login = 'panelinhadees'
-  const maxNumberOfRepositories = 4;
+  const maxNumberOfRepositories = 5;
   const repositoriesPath =  ['organization', 'repositories'];
   const { query } = createTestClient(testServer);
 
   it('repositories: Repository', async () => {
     const { data } = await query({
       query: queries.repositories,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
     expect(data).toEqual(expectedResult.repositories);
   });
@@ -21,7 +20,7 @@ describe('Repository type tests', () => {
   it('repositories: { name }: Repository', async () => {
     const { data } = await query({
       query: queries.repositoriesName,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
 
     const expectedResultRepositoriesName = getPropsFromList(
@@ -35,7 +34,7 @@ describe('Repository type tests', () => {
   it('repositories: { name, viewerCanAdminister }: Repository', async () => {
     const { data } = await query({
       query: queries.repositoriesNameViewerCanAdminister,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
 
     const expectedResultRepositoriesNameViewerCanAdminister = getPropsFromList(
@@ -49,7 +48,7 @@ describe('Repository type tests', () => {
   it('repositories: { totalForks, totalOpenIssues, totalStars }: Repository', async () => {
     const { data } = await query({
       query: queries.repositoriesTotalForksTotalOpenIssuesTotalStars,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
 
     const expectedResultRepositoriesTotalForksTotalOpenIssuesTotalStars = getPropsFromList(
@@ -65,7 +64,7 @@ describe('Repository type tests', () => {
   it('repositories: { id, totalForks, totalOpenIssues, totalStars }: Repository', async () => {
     const { data } = await query({
       query: queries.repositoriesIdTotalForksTotalOpenIssuesTotalStars,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
 
     const expectedResultRepositoriesIdTotalForksTotalOpenIssuesTotalStars = getPropsFromList(
@@ -81,7 +80,7 @@ describe('Repository type tests', () => {
   it('repositories { totalCommits }: Repository', async () => {
     const { data } = await query({
       query: queries.repositoriesTotalCommits,
-      variables: { login, maxNumberOfRepositories },
+      variables: { maxNumberOfRepositories },
     });
 
     expect(data).toEqual(expectedResult.repositoriesTotalCommits);

--- a/src/schema/organization/resolvers.js
+++ b/src/schema/organization/resolvers.js
@@ -2,6 +2,9 @@ import fetchData from '../../github/dataFetcher';
 import fetchRestData from '../../github/restDataFetcher';
 import githubQueries from '../../github/queries';
 
+import 'dotenv/config';
+import config from '../../config';
+
 export default {
   Query: {
     commits: async (parent, args, { token }) => {
@@ -24,7 +27,8 @@ export default {
       return data.data.search.issueCount;
     },
     organization: async (parent, args, { token }) => {
-      const body = githubQueries.organization(args.login);
+      const login = config.github.organization;
+      const body = githubQueries.organization(login);
       const data = await fetchData(body, token);
 
       const org = data.data.repositoryOwner;

--- a/src/schema/organization/teams/__tests__/api.js
+++ b/src/schema/organization/teams/__tests__/api.js
@@ -15,8 +15,8 @@ import gql from 'graphql-tag';
  *                   of the desired `organization`
  * */
 const teams = gql`
-  query teams($login: String!, $maxNumberOfTeams: Int!) {
-    organization(login: $login) {
+  query teams($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         id
         name
@@ -39,8 +39,8 @@ const teams = gql`
  *                   of the desired `organization`
  * */
 const teamsName = gql`
-  query teamsName($login: String!, $maxNumberOfTeams: Int!) {
-    organization(login: $login) {
+  query teamsName($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
       }
@@ -58,8 +58,8 @@ const teamsName = gql`
  *                   of the desired `organization`
  * */
 const teamsIdUrl = gql`
-  query teamsIdUrl($login: String!, $maxNumberOfTeams: Int!) {
-    organization(login: $login) {
+  query teamsIdUrl($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         id
         url
@@ -79,11 +79,8 @@ const teamsIdUrl = gql`
  *                   of the desired `organization`
  * */
 const teamsSlugTotalMembersRepoLogin = gql`
-  query teamsSlugTotalMembersRepoLogin(
-    $login: String!
-    $maxNumberOfTeams: Int!
-  ) {
-    organization(login: $login) {
+  query teamsSlugTotalMembersRepoLogin($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         slug
         totalMembers
@@ -105,11 +102,8 @@ const teamsSlugTotalMembersRepoLogin = gql`
  *                   of the desired `organization`
  * */
 const teamsNameSlugTotalMembersRepoLogin = gql`
-  query teamsNameSlugTotalMembersRepoLogin(
-    $login: String!
-    $maxNumberOfTeams: Int!
-  ) {
-    organization(login: $login) {
+  query teamsNameSlugTotalMembersRepoLogin($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
         slug
@@ -133,11 +127,8 @@ const teamsNameSlugTotalMembersRepoLogin = gql`
  *                   of the desired `organization`
  * */
 const teamsNameUrlSlugTotalMembersRepoLogin = gql`
-  query teamsNameUrlSlugTotalMembersRepoLogin(
-    $login: String!
-    $maxNumberOfTeams: Int!
-  ) {
-    organization(login: $login) {
+  query teamsNameUrlSlugTotalMembersRepoLogin($maxNumberOfTeams: Int!) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
         url
@@ -160,11 +151,10 @@ const teamsNameUrlSlugTotalMembersRepoLogin = gql`
  * */
 const teamsMembers = gql`
   query teamsMembers(
-    $login: String!
     $maxNumberOfTeams: Int!
     $maxNumberOfMembers: Int!
   ) {
-    organization(login: $login) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
         members(maxNumberOfMembers: $maxNumberOfMembers) {
@@ -186,11 +176,10 @@ const teamsMembers = gql`
  * */
 const teamsMembersLogin = gql`
   query teamsMembersLogin(
-    $login: String!
     $maxNumberOfTeams: Int!
     $maxNumberOfMembers: Int!
   ) {
-    organization(login: $login) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
         members(maxNumberOfMembers: $maxNumberOfMembers) {
@@ -211,11 +200,10 @@ const teamsMembersLogin = gql`
  * */
 const teamsMembersId = gql`
   query teamsMembersId(
-    $login: String!
     $maxNumberOfTeams: Int!
     $maxNumberOfMembers: Int!
   ) {
-    organization(login: $login) {
+    organization {
       teams(maxNumberOfTeams: $maxNumberOfTeams) {
         name
         members(maxNumberOfMembers: $maxNumberOfMembers) {

--- a/src/schema/organization/teams/__tests__/teams.spec.js
+++ b/src/schema/organization/teams/__tests__/teams.spec.js
@@ -5,7 +5,6 @@ import testServer from '../../../../testUtils/integration/serverFactory';
 import { getPropsFromList } from '../../../../testUtils/integration/dataExtractor';
 
 describe('Team type tests', () => {
-  const login = 'panelinhadees';
   const maxNumberOfTeams = 10;
   const maxNumberOfMembers = 10;
   const teamsPath = ['organization', 'teams'];
@@ -14,7 +13,7 @@ describe('Team type tests', () => {
   it('teams: Team', async () => {
     const { data } = await query({
       query: queries.teams,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
     expect(data).toEqual(expectedResult.teams);
   });
@@ -22,7 +21,7 @@ describe('Team type tests', () => {
   it('teams { name }: Team', async () => {
     const { data } = await query({
       query: queries.teamsName,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
 
     const expectedResultTeamsName = getPropsFromList(
@@ -36,7 +35,7 @@ describe('Team type tests', () => {
   it('teams { id, url }: Team', async () => {
     const { data } = await query({
       query: queries.teamsIdUrl,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
 
     const expectedResultTeamsIdUrl = getPropsFromList(
@@ -50,7 +49,7 @@ describe('Team type tests', () => {
   it('teams { slug, totalMembers, repoLogin }: Team', async () => {
     const { data } = await query({
       query: queries.teamsSlugTotalMembersRepoLogin,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
 
     const expectedResultTeamsSlugTotalMembersRepoLogin = getPropsFromList(
@@ -64,7 +63,7 @@ describe('Team type tests', () => {
   it('teams { name, slug, totalMembers, repoLogin }: Team', async () => {
     const { data } = await query({
       query: queries.teamsNameSlugTotalMembersRepoLogin,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
 
     const expectedResultTeamsNameSlugTotalMembersRepoLogin = getPropsFromList(
@@ -78,7 +77,7 @@ describe('Team type tests', () => {
   it('teams { name, url, slug, totalMembers, repoLogin }: Team', async () => {
     const { data } = await query({
       query: queries.teamsNameUrlSlugTotalMembersRepoLogin,
-      variables: { login, maxNumberOfTeams },
+      variables: { maxNumberOfTeams },
     });
 
     const expectedResultTeamsNameUrlSlugTotalMembersRepoLogin = getPropsFromList(
@@ -92,7 +91,7 @@ describe('Team type tests', () => {
   it('teams { name, members { id, login } }: Team', async () => {
     const { data } = await query({
       query: queries.teamsMembers,
-      variables: { login, maxNumberOfTeams, maxNumberOfMembers },
+      variables: { maxNumberOfTeams, maxNumberOfMembers },
     });
 
     expect(data).toEqual(expectedResult.teamsMembers);
@@ -101,7 +100,7 @@ describe('Team type tests', () => {
   it('teams { name, members { login } }: Team', async () => {
     const { data } = await query({
       query: queries.teamsMembersLogin,
-      variables: { login, maxNumberOfTeams, maxNumberOfMembers },
+      variables: { maxNumberOfTeams, maxNumberOfMembers },
     });
 
     expect(data).toEqual(expectedResult.teamsMembersLogin);
@@ -110,7 +109,7 @@ describe('Team type tests', () => {
   it('teams { name, members { id } }: Team', async () => {
     const { data } = await query({
       query: queries.teamsMembersId,
-      variables: { login, maxNumberOfTeams, maxNumberOfMembers },
+      variables: { maxNumberOfTeams, maxNumberOfMembers },
     });
 
     expect(data).toEqual(expectedResult.teamsMembersId);


### PR DESCRIPTION
# Description

This PR makes possible the obtaining of organization data from the login at .env file. In organization resolvers, now instead of expecting a parameter with the organization login, we get it from .env file.

Fixes #93.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
To be able to use the tests correctly, you will need to define a github token that will be used for the tests of the requisitions, it is set in .env, check the .env.example in the project root, once you have defined the same execute the command:

`npm run test`

Note: Currently the expectedResult is set for the `panelinhadees` organization, just as an example, however, if you use your token, it will be another user logged in, so in order for it to work you should replace its information with your.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules