### PR TITLE
Add totalIssues and totalPullRequests to contributor

### DIFF
--- a/src/github/queries.js
+++ b/src/github/queries.js
@@ -28,6 +28,8 @@ const simpleContributorFields = `
   avatarUrl
   contributionsCollection(organizationID: $orgID) {
     totalCommitContributions
+    totalIssueContributions
+    totalPullRequestContributions
   }
 `;
 
@@ -113,21 +115,7 @@ const getContributorData = (inputs, data, variables) => {
   return JSON.stringify({query, variables});
 }
 
-const getContributorsData = (data, info) => {
-  const inputs = `
-    $login: String!, 
-    $firstRepos: Int!, 
-    $firstUsers: Int!, 
-    $afterRepos: String,
-    $afterUsers: String,
-  `;
-
-  const { id: orgID, login } = info.organization;
-  const { after: afterRepos, first: firstRepos } = info.repoArgs;
-  const { after: afterUsers, first: firstUsers } = info.userArgs;
-
-  const variables = {orgID, login, firstRepos, firstUsers, afterRepos, afterUsers};
-
+const getContributorsData = (inputs, data, variables) => {
   const query = `
     query getContributors(${inputs}) {
       organization(login: $login) {
@@ -154,9 +142,23 @@ const getContributorsData = (data, info) => {
  * @param {object} userArgs object with args (first, after, etc) to filter metionableUsers
  */
 const contributors = (organization, repoArgs, userArgs) => {
+  const inputs = `
+    $login: String!, 
+    $orgID: ID!,
+    $firstRepos: Int!, 
+    $firstUsers: Int!, 
+    $afterRepos: String,
+    $afterUsers: String,
+  `;
+
   const data = simpleContributorFields;
-  const info = {organization, repoArgs, userArgs};
-  return getContributorsData(data, info);
+
+  const { id: orgID, login } = organization;
+  const { after: afterRepos, first: firstRepos } = repoArgs;
+  const { after: afterUsers, first: firstUsers } = userArgs;
+  const variables = {orgID, login, firstRepos, firstUsers, afterRepos, afterUsers};
+
+  return getContributorsData(inputs, data, variables);
 }
 
 const getOrganizationData = (inputs, data, variables) => {

--- a/src/schema/organization/contributors/types.js
+++ b/src/schema/organization/contributors/types.js
@@ -24,6 +24,8 @@ const ContributorType = new GraphQLObjectType({
     avatarUrl: { type: GraphQLString },
     firstContributionDate: { type: GraphQLDate },
     totalCommits: { type: GraphQLInt },
+    totalIssues: { type: GraphQLInt },
+    totalPullRequests: { type: GraphQLInt },
     totalIssuesOpen: {
       type: GraphQLInt,
       resolve: resolvers.Query.openIssues,


### PR DESCRIPTION
# Description
Add **totalIssues** and **totalPullrequests** to both contributor(login) and contributors(...) queries. Also, I improve and remove small unused code from `src/schema/organization/contributors/resolver.js`

Fixes #103

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I ran the server and do tests on GraphQL Playground. As the information is updating very fast, I couldn't do unit tests because the values get outdate easly. With that said, you will have to compare the value from query with the showed on GitHub.

**Queries used:**
```GraphQL
query getTotalIssuesAndPrFromSingleContributor {
  organization {
    contributor(login:"jadsonluan") {
      login
      totalIssues
      totalPullRequests
    }
  }
}
```

```GraphQL
query getTotalIssuesAndPrFromTenContributors {
  organization {
    contributors(first: 10) {
      login
      totalIssues
      totalPullRequests
    }
  }
```

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules