### PR TITLE
Adds description for queries, types and fields on the schema

### DIFF
--- a/src/schema/organization/contributors/queries.js
+++ b/src/schema/organization/contributors/queries.js
@@ -22,7 +22,8 @@ export const contributors = {
       description: '[NOT IMPLEMENTED YET] Returns the elements in the list that come after the specified cursor.'
     }
   },
-  resolve: resolvers.Query.contributors
+  resolve: resolvers.Query.contributors,
+  description: 'A list of contributors in this organization.',
 };
 
 export const contributor = {
@@ -34,4 +35,5 @@ export const contributor = {
     },
   },
   resolve: resolvers.Query.contributor,
+  description: `Find an organization's contributor by its login.`,
 }

--- a/src/schema/organization/contributors/types.js
+++ b/src/schema/organization/contributors/types.js
@@ -14,33 +14,73 @@ const ContributorType = new GraphQLObjectType({
     'An individual account on GitHub that owns repositories and can make new content.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    login: { type: GraphQLString },
-    name: { type: GraphQLString },
-    location: { type: GraphQLString },
-    bio: { type: GraphQLString },
-    email: { type: GraphQLString },
-    websiteUrl: { type: GraphQLString },
-    avatarUrl: { type: GraphQLString },
-    firstContributionDate: { type: GraphQLDate },
-    totalCommits: { type: GraphQLInt },
-    totalIssues: { type: GraphQLInt },
-    totalPullRequests: { type: GraphQLInt },
+    id: {
+      type: GraphQLID,
+      description: 'Contributor ID.',
+    },
+    login: {
+      type: GraphQLString,
+      description: 'Contributor login.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Contributor name.',
+    },
+    location: {
+      type: GraphQLString,
+      description: `The contributor's public profile location.`,
+    },
+    bio: {
+      type: GraphQLString,
+      description: `The contributor's public profile bio.`,
+    },
+    email: {
+      type: GraphQLString,
+      description: `The contributor's publicly visible profile email.`,
+    },
+    websiteUrl: {
+      type: GraphQLString,
+      description: `A URL pointing to the contributor's public website.`,
+    },
+    avatarUrl: {
+      type: GraphQLString,
+      description: `A URL pointing to the contributor's public profile picture (avatar).`,
+    },
+    firstContributionDate: {
+      type: GraphQLDate,
+      description: 'Date of the first time the contributor has contributed to the organization.',
+    },
+    totalCommits: {
+      type: GraphQLInt,
+      description: 'How many commits were made by the contributor in the organization.',
+    },
+    totalIssues: {
+      type: GraphQLInt,
+      description: 'How many issues were opened by the contributor in the organization.',
+    },
+    totalPullRequests: {
+      type: GraphQLInt,
+      description: 'How many pull requests were opened by the contributor in the organization.',
+    },
     totalIssuesOpen: {
       type: GraphQLInt,
       resolve: resolvers.Query.openIssues,
+      description: 'How many issues were opened by the contributor in the organization and are still open.',
     },
     totalIssuesClosed: {
       type: GraphQLInt,
       resolve: resolvers.Query.closedIssues,
+      description: 'How many issues were opened by the contributor in the organization and were closed.',
     },
     totalPullRequestsOpen: {
       type: GraphQLInt,
       resolve: resolvers.Query.openPullRequests,
+      description: 'How many pull requests were opened by the contributor in the organization and are still open.',
     },
     totalPullRequestsClosed: {
       type: GraphQLInt,
       resolve: resolvers.Query.closedPullRequests,
+      description: 'How many pull requests were opened by the contributor in the organization and were closed.',
     },
   }),
 });

--- a/src/schema/organization/members/queries.js
+++ b/src/schema/organization/members/queries.js
@@ -12,6 +12,7 @@ const members = {
     },
   },
   resolve: resolvers.Query.members,
+  description: 'A list of members in this organization.',
 };
 
 export default members;

--- a/src/schema/organization/members/types.js
+++ b/src/schema/organization/members/types.js
@@ -5,11 +5,26 @@ const OrganizationMemberType = new GraphQLObjectType({
   description: 'A user within an organization.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    name: { type: GraphQLString },
-    login: { type: GraphQLString },
-    role: { type: GraphQLString },
-    url: { type: GraphQLString },
+    id: {
+      type: GraphQLID,
+      description: 'Member ID.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Member name.',
+    },
+    login: {
+      type: GraphQLString,
+      description: 'Member login.',
+    },
+    role: {
+      type: GraphQLString,
+      description: 'The role this member has in the organization.',
+    },
+    url: {
+      type: GraphQLString,
+      description: 'The HTTP URL for this member.',
+    },
   }),
 });
 

--- a/src/schema/organization/queries.js
+++ b/src/schema/organization/queries.js
@@ -4,6 +4,7 @@ import resolvers from './resolvers';
 const organization = {
   type: OrganizationType,
   resolve: resolvers.Query.organization,
+  description: 'Lookup an organization by login defined on server configuration.',
 };
 
 export default {

--- a/src/schema/organization/repositories/queries.js
+++ b/src/schema/organization/repositories/queries.js
@@ -12,6 +12,7 @@ const repositories = {
     },
   },
   resolve: resolvers.Query.repositories,
+  description: 'A list of repositories in this organization.',
 };
 
 export default repositories;

--- a/src/schema/organization/repositories/types.js
+++ b/src/schema/organization/repositories/types.js
@@ -11,14 +11,38 @@ const RepositoryType = new GraphQLObjectType({
   description: 'A repository contains the content for a project.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    name: { type: GraphQLString },
-    viewerCanAdminister: { type: GraphQLBoolean },
-    totalForks: { type: GraphQLInt },
-    totalOpenIssues: { type: GraphQLInt },
-    totalOpenPullRequests: { type: GraphQLInt },
-    totalStars: { type: GraphQLInt },
-    totalCommits: { type: GraphQLInt },
+    id: {
+      type: GraphQLID,
+      description: 'Repository ID.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Repository name.',
+    },
+    viewerCanAdminister: {
+      type: GraphQLBoolean,
+      description: 'Indicates whether the viewer has admin permissions on the repository.',
+    },
+    totalForks: {
+      type: GraphQLInt,
+      description: `The repository's total number of forks.`,
+    },
+    totalOpenIssues: {
+      type: GraphQLInt,
+      description: `The repository's total number of open issues.`,
+    },
+    totalOpenPullRequests: {
+      type: GraphQLInt,
+      description: `The repository's total number of open pull requests.`,
+    },
+    totalStars: {
+      type: GraphQLInt,
+      description: `The repository's total number of stars.`,
+    },
+    totalCommits: {
+      type: GraphQLInt,
+      description: `The repository's total number of commits.`,
+    },
   }),
 });
 

--- a/src/schema/organization/teams/queries.js
+++ b/src/schema/organization/teams/queries.js
@@ -12,6 +12,7 @@ const teams = {
     },
   },
   resolve: resolvers.Query.teams,
+  description: 'A list of teams in this organization.',
 };
 
 export default teams;

--- a/src/schema/organization/teams/resolvers.js
+++ b/src/schema/organization/teams/resolvers.js
@@ -22,7 +22,7 @@ const addTeamsToArray = (teams, teamsArray, login) => {
       id: teamId,
       name: teamName,
       url: teamUrl,
-      repoLogin: login,
+      orgLogin: login,
       slug: teamSlug,
       totalMembers: teamTotalMembers,
     });
@@ -46,7 +46,7 @@ export default {
     },
 
     teamMembers: async (parent, args, { token }) => {
-      const login = parent.repoLogin;
+      const login = parent.orgLogin;
       const { slug } = parent;
       const pagination = args.maxNumberOfMembers;
       const teamMembersArray = [];

--- a/src/schema/organization/teams/types.js
+++ b/src/schema/organization/teams/types.js
@@ -14,8 +14,14 @@ const TeamMemberType = new GraphQLObjectType({
   description: 'A user who is a member of a team.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    login: { type: GraphQLString },
+    id: {
+      type: GraphQLID,
+      description: 'Team member ID.',
+    },
+    login: {
+      type: GraphQLString,
+      description: 'Team member login.',
+    },
   }),
 });
 
@@ -24,12 +30,30 @@ const TeamType = new GraphQLObjectType({
   description: 'A team of users in an organization.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    name: { type: GraphQLString },
-    slug: { type: GraphQLString },
-    url: { type: GraphQLString },
-    totalMembers: { type: GraphQLInt },
-    repoLogin: { type: GraphQLString },
+    id: {
+      type: GraphQLID,
+      description: 'Team ID.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Team name.',
+    },
+    slug: {
+      type: GraphQLString,
+      description: 'The slug corresponding to the team.',
+    },
+    url: {
+      type: GraphQLString,
+      description: 'The HTTP URL for this team.',
+    },
+    totalMembers: {
+      type: GraphQLInt,
+      description: `The team's total number of members.`,
+    },
+    orgLogin: {
+      type: GraphQLString,
+      description: 'The login of the organization which this team belongs.',
+    },
     members: {
       type: new GraphQLList(TeamMemberType),
       args: {
@@ -39,6 +63,7 @@ const TeamType = new GraphQLObjectType({
         },
       },
       resolve: resolvers.Query.teamMembers,
+      description: 'A list of members in this team.',
     },
   }),
 });

--- a/src/schema/organization/types.js
+++ b/src/schema/organization/types.js
@@ -17,15 +17,42 @@ const OrganizationType = new GraphQLObjectType({
     'An account on GitHub, with one or more owners, that has repositories, members and teams.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    name: { type: GraphQLString },
-    login: { type: GraphQLString },
-    avatarUrl: { type: GraphQLString },
-    url: { type: GraphQLString },
-    websiteUrl: { type: GraphQLString },
-    totalMembers: { type: GraphQLInt },
-    totalRepos: { type: GraphQLInt },
-    totalTeams: { type: GraphQLInt },
+    id: {
+      type: GraphQLID,
+      description: 'Organization ID.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Organization name.',
+    },
+    login: {
+      type: GraphQLString,
+      description: 'Organization login.',
+    },
+    avatarUrl: {
+      type: GraphQLString,
+      description: 'Organization profile picture (avatar) URL.',
+    },
+    url: {
+      type: GraphQLString,
+      description: 'The HTTP URL for this organization.',
+    },
+    websiteUrl: {
+      type: GraphQLString,
+      description: `The organization's public profile URL.`,
+    },
+    totalMembers: {
+      type: GraphQLInt,
+      description: `The organization's total number of members.`,
+    },
+    totalRepos: {
+      type: GraphQLInt,
+      description: `The organization's total number of repositories.`,
+    },
+    totalTeams: {
+      type: GraphQLInt,
+      description: `The organization's total number of teams.`,
+    },
     teams,
     members,
     repositories,
@@ -34,14 +61,17 @@ const OrganizationType = new GraphQLObjectType({
     totalPullRequests: { 
       type: GraphQLInt,
       resolve: resolvers.Query.pullRequests,
+      description: `The organization's total number of pull requests.`,
     },
     totalCommits: {
       type: GraphQLInt,
       resolve: resolvers.Query.commits,
+      description: `The organization's total number of commits.`,
     },
     totalIssues: {
       type: GraphQLInt,
       resolve: resolvers.Query.issues,
+      description: `The organization's total number of issues.`,
     }
   }),
 });

--- a/src/schema/user/queries.js
+++ b/src/schema/user/queries.js
@@ -4,6 +4,7 @@ import resolvers from './resolvers';
 const me = {
   type: UserType,
   resolve: resolvers.Query.me,
+  description: 'The currently authenticated user.',
 };
 
 export default {

--- a/src/schema/user/types.js
+++ b/src/schema/user/types.js
@@ -11,14 +11,38 @@ const UserType = new GraphQLObjectType({
     'An individual account on GitHub that owns repositories and can make new content.',
 
   fields: () => ({
-    id: { type: GraphQLID },
-    login: { type: GraphQLString },
-    name: { type: GraphQLString },
-    location: { type: GraphQLString },
-    bio: { type: GraphQLString },
-    email: { type: GraphQLString },
-    websiteUrl: { type: GraphQLString },
-    totalRepos: { type: GraphQLInt }
+    id: {
+      type: GraphQLID,
+      description: 'Logged user ID.',
+    },
+    login: {
+      type: GraphQLString,
+      description: 'Logged user username used to login.',
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Logged user name.',
+    },
+    location: {
+      type: GraphQLString,
+      description: `The logged user's public profile location.`,
+    },
+    bio: {
+      type: GraphQLString,
+      description: `The logged user's public profile bio.`,
+    },
+    email: {
+      type: GraphQLString,
+      description: `The logged user's publicly visible profile email.`,
+    },
+    websiteUrl: {
+      type: GraphQLString,
+      description: `A URL pointing to the logged user's public website.`,
+    },
+    totalRepos: {
+      type: GraphQLInt,
+      description: `The logged user's total number of repositories.`,
+    },
   })
 });
 


### PR DESCRIPTION
# Description

This PR adds description field for everything (queries, fields and types) that makes up our schema, because we had few documentation for our Schema, and GraphQL facilitates it by providing a "description" field for fields, types, queries, mutations, ... Basically everything.

Fixes #105.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules